### PR TITLE
Align POM version dependencies to bring to alignment with current version of CDAP and Hydrator-Plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.5.0-SNAPSHOT</cdap.version>
+    <hydrator.version>2.8.0-SNAPSHOT</hydrator.version>
     <hadoop.version>2.3.0</hadoop.version>
     <junit.version>4.11</junit.version>
     <widgets.dir>widgets</widgets.dir>


### PR DESCRIPTION
Currently project as it exists will not build with mvn error

Aligning versions to current ones existing in sonatype to allow passing build and mvn package